### PR TITLE
Fix docs/setup

### DIFF
--- a/docs/setup.lisp
+++ b/docs/setup.lisp
@@ -1,8 +1,13 @@
 (in-package #:cl-containers-documentation)
 
-(defmethod additional-markdown-extensions-for-system 
+;; NB: This method is not right to put here, rightfully causes an ASDF warning,
+;; and should be moved to some file that depends on both
+;; cl-containers-documentation and lift-documentation.
+#|
+(defmethod additional-markdown-extensions-for-system
     append ((system (eql (asdf:find-system 'lift-documentation))))
   '(clcl))
+|#
 
 (defsimple-extension clcl
   "*CL-Containers*")
@@ -15,7 +20,7 @@
      ;; could syntax check here
      )
     (:render
-     (format *output-stream* "~s ~s" root filter))))
+     (format *standard-output* "~s ~s" root filter))))
 
 #|
 


### PR DESCRIPTION
Resolve two warnings:
- find-system can't be used in a regular .lisp file where one of the system hasn't been defined already. This looks like the wrong file for this configuration item.
- `*output-stream*` is undefined and probably `*standard-output*` or `t` is meant.

Requesting review by @gwkkwg.